### PR TITLE
Feat/emitter start stop types

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -35,15 +35,6 @@ Wawa VFX makes it easy to create particle effects in your React Three Fiber proj
 import { VFXEmitter, VFXParticles } from "wawa-vfx";
 
 const MyEffect = () => {
-  const emitterRef = useRef<VFXEmitterProps>(null);
-  
-  useFrame(() => {
-    if(emitterRef.current) {
-      emitterRef.current.startEmitting(); // by default is true, but you can set it to false to start the emission without using a React re-Rendering if shouldEmit is false
-      emitterRef.current.stopEmitting(); // Stop emitting particles without causing a React re-Rendering if shouldEmit is false
-    }
-  })
-
   return (
     <>
       {/* Step 1: Define your particle system */}
@@ -62,7 +53,6 @@ const MyEffect = () => {
       {/* Step 2: Define your emitter */}
       <VFXEmitter
         debug // Show debug visualization
-        ref={emitterRef}
         emitter="particles" // Target the particle system by name
         settings={{
           loop: true, // Continuously emit particles (only if `spawnMode` is 'time')
@@ -134,3 +124,16 @@ const MyEffect = () => {
 ## Advanced Usage
 
 Check out the `examples` directory for more complex implementations and techniques.
+
+## Roadmap
+
+Do you want to contribute to the project? Here are some ideas for future features:
+
+- [ ] WebGPU/TSL `VFXParticles`/`VFXParticlesMaterial` versions
+- [ ] Performance optimizations (Points / Sprites)
+- [ ] More controls on the `VFXEmitter` component (`emit`, `emitStart`, `emitStop`, `emitByDistance`)
+- [ ] More customization options for the particle system
+- [ ] More rendering modes (`stretched billboard`)
+- [ ] More examples and documentation
+
+Feel free to open an issue or PR if you have any suggestions or improvements!

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wawa-vfx",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wawa-vfx",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "leva": "^0.10.0",

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wawa-vfx",
   "private": false,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "main": "dist/wawa-vfx.umd.js",

--- a/packages/src/components/Experience.tsx
+++ b/packages/src/components/Experience.tsx
@@ -1,28 +1,34 @@
 import { Environment, OrbitControls, Stats } from "@react-three/drei";
 import { useFrame } from "@react-three/fiber";
 import { Bloom, EffectComposer } from "@react-three/postprocessing";
+import { button, useControls } from "leva";
 import { useRef } from "react";
-import { Object3D } from "three";
-import VFXEmitter from "./vfxs/VFXEmitter";
+import VFXEmitter, { VFXEmitterRef } from "./vfxs/VFXEmitter";
 import VFXParticles from "./vfxs/VFXParticles";
 
-export interface VFXEmitterMethods extends Object3D {
-  stopEmitting: () => void;
-  startEmitting: () => void;
-}
-
 export const Experience = () => {
-  const emitterBlue = useRef<VFXEmitterMethods>(null);
+  const emitterBlue = useRef<VFXEmitterRef>(null);
+
+  useControls("Emitter External Controls", {
+    start: button(() => {
+      emitterBlue.current?.startEmitting();
+    }),
+    startWithReset: button(() => {
+      emitterBlue.current?.startEmitting(true);
+    }),
+    stop: button(() => {
+      emitterBlue.current?.stopEmitting();
+    }),
+  });
 
   useFrame(({ clock }) => {
     const time = clock.getElapsedTime();
 
-  
     if (emitterBlue.current) {
       emitterBlue.current.position.x = Math.cos(time * 6) * 1.5;
       emitterBlue.current.position.y = Math.sin(time * 3) * 1.5;
       emitterBlue.current.position.z = Math.cos(time * 4) * 1.5;
-      
+
       // now you can stop or start emitting using the methods stopEmitting or startEmitting by accessing the emitterBlue ref.current object
     }
   });

--- a/packages/src/components/vfxs/VFXEmitter.tsx
+++ b/packages/src/components/vfxs/VFXEmitter.tsx
@@ -45,10 +45,14 @@ interface VFXEmitterProps {
   debug: boolean;
   settings: VFXEmitterSettings;
   emitter: string;
-  ref?: React.RefObject<THREE.Object3D>;
 }
 
-const VFXEmitter = forwardRef<THREE.Object3D, VFXEmitterProps>(
+export interface VFXEmitterRef extends THREE.Object3D {
+  startEmitting: (reset?: boolean) => void;
+  stopEmitting: () => void;
+}
+
+const VFXEmitter = forwardRef<VFXEmitterRef, VFXEmitterProps>(
   ({ debug, emitter, settings = {}, ...props }, forwardedRef) => {
     const [
       {
@@ -77,12 +81,16 @@ const VFXEmitter = forwardRef<THREE.Object3D, VFXEmitterProps>(
     const emit = useVFX((state) => state.emit);
 
     const shouldEmitRef = useRef<boolean>(true);
-    
+
     const stopEmitting = useCallback(() => {
       shouldEmitRef.current = false;
     }, []);
 
-    const startEmitting = useCallback(() => {
+    const startEmitting = useCallback((reset: boolean = false) => {
+      if (reset) {
+        emitted.current = 0;
+        elapsedTime.current = 0;
+      }
       shouldEmitRef.current = true;
     }, []);
 


### PR DESCRIPTION
Kudos to @Lunakepio for his [PR](https://github.com/wass08/wawa-vfx/pull/1), this PR is some adjustments + publishing the update to NPM:
- Set types properly
- Added `reset` parameter to `startEmitting` to allow to trigger `burst`
- Updated package version
