### PR TITLE
Add blendingMode prop to VFXParticles component

### DIFF
--- a/packages/src/components/vfxs/VFXParticles.tsx
+++ b/packages/src/components/vfxs/VFXParticles.tsx
@@ -3,7 +3,6 @@ import { extend, useFrame } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
 import {
-  AdditiveBlending,
   Color,
   DynamicDrawUsage,
   Euler,
@@ -16,6 +15,7 @@ import { EmitCallbackSettingsFn, useVFX } from "./VFXStore";
 import { easings } from "./easings";
 import {
   AppearanceMode,
+  BlendingMode,
   EaseFunction,
   easeFunctionList,
   RenderMode,
@@ -39,6 +39,7 @@ interface VFXParticlesSettings {
   frustumCulled?: boolean;
   appearance?: AppearanceMode;
   easeFunction?: EaseFunction;
+  blendingMode?: BlendingMode;
 }
 
 interface VFXParticlesProps {
@@ -65,6 +66,7 @@ const VFXParticles: React.FC<VFXParticlesProps> = ({
     frustumCulled = true,
     appearance = AppearanceMode.Square,
     easeFunction = "easeLinear",
+    blendingMode = BlendingMode.AdditiveBlending,
   } = settings;
   const mesh = useRef<THREE.InstancedMesh>(null!);
   const defaultGeometry = useMemo(() => new PlaneGeometry(0.5, 0.5), []);
@@ -207,6 +209,7 @@ const VFXParticles: React.FC<VFXParticlesProps> = ({
     material.uniforms.uGravity.value = gravity;
     material.uniforms.uAppearanceMode.value = appearance;
     material.uniforms.uEasingFunction.value = easingIndex;
+    material.uniforms.uBlendingMode.value = blendingMode;
   });
 
   const registerEmitter = useVFX((state) => state.registerEmitter);
@@ -235,7 +238,7 @@ const VFXParticles: React.FC<VFXParticlesProps> = ({
       >
         {geometry}
         <particlesMaterial
-          blending={AdditiveBlending}
+          blending={blendingMode}
           defines={{
             STRETCH_BILLBOARD_MODE: renderMode === "stretchBillboard",
             BILLBOARD_MODE: renderMode === "billboard",
@@ -303,6 +306,7 @@ const ParticlesMaterial = shaderMaterial(
     uAppearanceMode: 0,
     alphaMap: null,
     uEasingFunction: 0,
+    uBlendingMode: 0,
   },
   /* glsl */ `
 ${easings}
@@ -352,6 +356,7 @@ uniform vec2 uFadeSize;
 uniform vec3 uGravity;
 uniform float uStretchScale;
 uniform int uEasingFunction;
+uniform int uBlendingMode;
 
 varying vec2 vUv;
 varying vec3 vColor;

--- a/packages/src/components/vfxs/VFXParticles.tsx
+++ b/packages/src/components/vfxs/VFXParticles.tsx
@@ -10,12 +10,13 @@ import {
   PlaneGeometry,
   Quaternion,
   Vector3,
+  Blending,
+  AdditiveBlending,
 } from "three";
 import { EmitCallbackSettingsFn, useVFX } from "./VFXStore";
 import { easings } from "./easings";
 import {
   AppearanceMode,
-  BlendingMode,
   EaseFunction,
   easeFunctionList,
   RenderMode,
@@ -39,7 +40,7 @@ interface VFXParticlesSettings {
   frustumCulled?: boolean;
   appearance?: AppearanceMode;
   easeFunction?: EaseFunction;
-  blendingMode?: BlendingMode;
+  blendingMode?: Blending;
 }
 
 interface VFXParticlesProps {
@@ -66,7 +67,7 @@ const VFXParticles: React.FC<VFXParticlesProps> = ({
     frustumCulled = true,
     appearance = AppearanceMode.Square,
     easeFunction = "easeLinear",
-    blendingMode = BlendingMode.AdditiveBlending,
+    blendingMode = AdditiveBlending,
   } = settings;
   const mesh = useRef<THREE.InstancedMesh>(null!);
   const defaultGeometry = useMemo(() => new PlaneGeometry(0.5, 0.5), []);
@@ -209,7 +210,6 @@ const VFXParticles: React.FC<VFXParticlesProps> = ({
     material.uniforms.uGravity.value = gravity;
     material.uniforms.uAppearanceMode.value = appearance;
     material.uniforms.uEasingFunction.value = easingIndex;
-    material.uniforms.uBlendingMode.value = blendingMode;
   });
 
   const registerEmitter = useVFX((state) => state.registerEmitter);
@@ -306,7 +306,6 @@ const ParticlesMaterial = shaderMaterial(
     uAppearanceMode: 0,
     alphaMap: null,
     uEasingFunction: 0,
-    uBlendingMode: 0,
   },
   /* glsl */ `
 ${easings}
@@ -356,7 +355,6 @@ uniform vec2 uFadeSize;
 uniform vec3 uGravity;
 uniform float uStretchScale;
 uniform int uEasingFunction;
-uniform int uBlendingMode;
 
 varying vec2 vUv;
 varying vec3 vColor;

--- a/packages/src/components/vfxs/types.ts
+++ b/packages/src/components/vfxs/types.ts
@@ -127,12 +127,3 @@ export const easeFunctionList: EaseFunction[] = [
   "easeOutBounce",
   "easeInOutBounce",
 ];
-
-export enum BlendingMode {
-  NoBlending = 0,
-  NormalBlending = 1, 
-  AdditiveBlending = 2,
-  SubtractiveBlending = 3,
-  MultiplyBlending = 4,
-  CustomBlending = 5,
-}

--- a/packages/src/components/vfxs/types.ts
+++ b/packages/src/components/vfxs/types.ts
@@ -127,3 +127,12 @@ export const easeFunctionList: EaseFunction[] = [
   "easeOutBounce",
   "easeInOutBounce",
 ];
+
+export enum BlendingMode {
+  NoBlending = 0,
+  NormalBlending = 1, 
+  AdditiveBlending = 2,
+  SubtractiveBlending = 3,
+  MultiplyBlending = 4,
+  CustomBlending = 5,
+}


### PR DESCRIPTION
BlendingMode was always "AdditiveBlending", made it possible to pick a different one.
Following issue https://github.com/wass08/wawa-vfx/issues/13